### PR TITLE
Task: Repair the heater unit to 100

### DIFF
--- a/Contents/mods/PatagoniaTools/media/lua/client/ISUI/Vehicles/ISUI/RepairHeaterMenu.lua
+++ b/Contents/mods/PatagoniaTools/media/lua/client/ISUI/Vehicles/ISUI/RepairHeaterMenu.lua
@@ -1,0 +1,129 @@
+local originalDoPartContextMenu = ISVehicleMechanics.doPartContextMenu
+
+local function predicateScrewdriver(item)
+    return item:hasTag("Screwdriver") or item:getType() == "Screwdriver"
+end
+
+function ISVehicleMechanics:doPartContextMenu(part, x, y)
+    originalDoPartContextMenu(self, part, x, y)
+
+    if (part:getId() == "Heater" and not VehicleUtils.RequiredKeyNotFound(part, self.chr)) then
+        local playerObj = getSpecificPlayer(self.playerNum)
+        local vehicle = part:getVehicle()
+
+        local option = self.context:addOption(getText("IGUI_Restore_Heater"), playerObj, ISVehicleMechanics.onRestoreHeater, part)
+        self:doMenuTooltip(part, option, "restore_heater")
+    end
+end
+
+function ISVehicleMechanics.onRestoreHeater(playerObj, part)
+
+    if playerObj:getVehicle() then
+        ISVehicleMenu.onExit(playerObj)
+    end
+
+    local typeToItem = VehicleUtils.getItems(playerObj:getPlayerNum())
+    local item = typeToItem["Base.Screwdriver"][1]
+    ISVehiclePartMenu.toPlayerInventory(playerObj, item)
+
+    ISTimedActionQueue.add(ISPathFindAction:pathToVehicleArea(playerObj, part:getVehicle(), "Engine"))
+
+    local engineCover = nil
+    local doorPart = part:getVehicle():getPartById("EngineDoor")
+    if doorPart and doorPart:getDoor() and doorPart:getInventoryItem() and not doorPart:getDoor():isOpen() then
+        engineCover = doorPart
+    end
+
+    local time = 1000
+    if engineCover then
+        if engineCover:getDoor():isLocked() and VehicleUtils.RequiredKeyNotFound(engineCover, playerObj) then
+            ISTimedActionQueue.add(ISUnlockVehicleDoor:new(playerObj, engineCover))
+        end
+        ISTimedActionQueue.add(ISOpenVehicleDoor:new(playerObj, part:getVehicle(), engineCover))
+        ISTimedActionQueue.add(ISRestoreHeater:new(playerObj, part, item, time))
+        ISTimedActionQueue.add(ISCloseVehicleDoor:new(playerObj, part:getVehicle(), engineCover))
+    else
+        ISTimedActionQueue.add(ISRestoreHeater:new(playerObj, part, item, time))
+    end
+end
+
+local originalDoMenuTooltip = ISVehicleMechanics.doMenuTooltip
+
+function ISVehicleMechanics:doMenuTooltip(part, option, lua, name)
+    originalDoMenuTooltip(self, part, option, lua, name)
+
+    if lua == "restore_heater" then
+        local vehicle = part:getVehicle()
+        local tooltip = ISToolTip:new()
+        tooltip:initialise()
+        tooltip:setVisible(false)
+        tooltip.description = ""
+        option.toolTip = tooltip
+
+        if (part:getCondition() >= 100) then
+            tooltip.description = string.format("%s %s <LINE>", tooltip.description, getText("Tooltip_part_full"))
+            tooltip.description = string.format("%s <RGB:0,1,1> %s <LINE>", tooltip.description, getText("Tooltip_vehicle_RestoreHeaterWarning"))
+            tooltip.description = string.format("%s <RGB:1,1,1>Mod: Patagonia tools", tooltip.description)
+            option.notAvailable = true
+            return
+        else
+            tooltip.description = tooltip.description .. getText("Tooltip_craft_Needs") .. " : <LINE>"
+        end
+
+        local electricityLevel = 8
+        if self.chr:getPerkLevel(Perks.Electricity) < electricityLevel then
+            rgb = ISVehicleMechanics.bhs
+            option.notAvailable = true
+        else
+            rgb = ISVehicleMechanics.ghs
+        end
+
+        tooltip.description = tooltip.description .. " " .. rgb .. getText("IGUI_perks_Electricity") .. " " .. self.chr:getPerkLevel(Perks.Electricity) .. "/" .. electricityLevel .. " <LINE>"
+
+        if self.chr:getInventory():containsEvalRecurse(predicateScrewdriver) then
+            tooltip.description = tooltip.description .. "<RGB:0,1,0> " .. getItemNameFromFullType("Base.Screwdriver") .. " 1 / 1" .. " <LINE>"
+        else
+            tooltip.description = tooltip.description .. "<RGB:1,0,0> " .. getItemNameFromFullType("Base.Screwdriver") .. " 0 / 1" .. " <LINE>"
+            option.notAvailable = true
+        end
+
+        local _aluminumInInventory = self.chr:getInventory():getNumberOfItem("Base.Aluminum", false, true)
+        local _aluminumRequired = 5
+
+        if _aluminumInInventory >= _aluminumRequired then
+            rgb = ISVehicleMechanics.ghs
+        else
+            rgb = ISVehicleMechanics.bhs
+            option.notAvailable = true
+        end
+
+        tooltip.description = tooltip.description .. " " .. rgb .. getItemNameFromFullType("Base.Aluminum") .. " " .. _aluminumInInventory .. "/" .. _aluminumRequired .. " <LINE>"
+
+        local _electronicsScrapInInventory = self.chr:getInventory():getNumberOfItem("Base.ElectronicsScrap", false, true)
+        local _electronicsScrapRequired = 8
+
+        if _electronicsScrapInInventory >= _electronicsScrapRequired then
+            rgb = ISVehicleMechanics.ghs
+        else
+            rgb = ISVehicleMechanics.bhs
+            option.notAvailable = true
+        end
+
+        tooltip.description = tooltip.description .. " " .. rgb .. getItemNameFromFullType("Base.ElectronicsScrap") .. " " .. _electronicsScrapInInventory .. "/" .. _electronicsScrapRequired .. " <LINE>"
+
+        local _electricWireInInventory = self.chr:getInventory():getNumberOfItem("Radio.ElectricWire", false, true)
+        local _electricWireRequired = 3
+
+        if _electricWireInInventory >= _electricWireRequired then
+            rgb = ISVehicleMechanics.ghs
+        else
+            rgb = ISVehicleMechanics.bhs
+            option.notAvailable = true
+        end
+
+        tooltip.description = tooltip.description .. " " .. rgb .. getItemNameFromFullType("Radio.ElectricWire") .. " " .. _electricWireInInventory .. "/" .. _electricWireRequired .. " <LINE>"
+
+        tooltip.description = string.format("%s <RGB:0,1,1> %s <LINE>", tooltip.description, getText("Tooltip_vehicle_RestoreHeaterWarning"))
+        tooltip.description = string.format("%s <RGB:1,1,1>Mod: Patagonia tools.", tooltip.description)
+    end
+end

--- a/Contents/mods/PatagoniaTools/media/lua/client/ISUI/Vehicles/TimedActions/ISRestoreHeater.lua
+++ b/Contents/mods/PatagoniaTools/media/lua/client/ISUI/Vehicles/TimedActions/ISRestoreHeater.lua
@@ -1,0 +1,70 @@
+require "TimedActions/ISBaseTimedAction"
+
+ISRestoreHeater = ISBaseTimedAction:derive("ISRestoreHeater")
+
+function ISRestoreHeater:isValid()
+    return true
+end
+
+function ISRestoreHeater:waitToStart()
+    self.character:faceThisObject(self.vehicle)
+    return self.character:shouldBeTurning()
+end
+
+function ISRestoreHeater:update()
+    self.character:faceThisObject(self.vehicle)
+    self.item:setJobDelta(self:getJobDelta())
+
+    if self.sound ~= 0 and not self.character:getEmitter():isPlaying(self.sound) then
+        self.sound = self.character:playSound("Dismantle")
+    end
+
+    self.character:setMetabolicTarget(Metabolics.HeavyWork)
+end
+
+function ISRestoreHeater:start()
+    self.item:setJobType(getText("IGUI_Restore_Heater"))
+    self:setActionAnim("Disassemble")
+    self:setOverrideHandModels(self.item, nil)
+    self.sound = self.character:playSound("Dismantle")
+end
+
+function ISRestoreHeater:stop()
+    if self.item then
+        self.item:setJobDelta(0)
+    end
+
+    if self.sound ~= 0 then
+        self.character:getEmitter():stopSound(self.sound)
+    end
+
+    ISBaseTimedAction.stop(self)
+end
+
+function ISRestoreHeater:perform()
+    if self.sound ~= 0 then
+        self.character:getEmitter():stopSound(self.sound)
+    end
+
+    ISBaseTimedAction.perform(self)
+    self.item:setJobDelta(0)
+
+    local args = {
+        vehicle = self.vehicle:getId()
+    }
+
+    sendClientCommand(self.character, 'vehicle', 'repairHeater', args)
+end
+
+function ISRestoreHeater:new(character, part, item, time)
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    o.character = character
+    o.vehicle = part:getVehicle()
+    o.part = part
+    o.item = item
+    o.maxTime = time
+    o.jobType = getText("IGUI_Restore_Heater")
+    return o
+end

--- a/Contents/mods/PatagoniaTools/media/lua/server/Vehicles/RepairHeaterCommands.lua
+++ b/Contents/mods/PatagoniaTools/media/lua/server/Vehicles/RepairHeaterCommands.lua
@@ -1,0 +1,37 @@
+local Commands = {}
+
+function Commands.repairHeater(player, args)
+    local vehicle = getVehicleById(args.vehicle)
+
+    if vehicle then
+        local part = vehicle:getPartById("Heater")
+        if not part then
+            noise('no such part heater')
+            return
+        end
+
+        player:sendObjectChange('removeItemType', { type = 'Base.Aluminum', count = 5 })
+        player:sendObjectChange('removeItemType', { type = 'Base.ElectronicsScrap', count = 10 })
+        player:sendObjectChange('removeItemType', { type = 'Radio.ElectricWire', count = 3 })
+
+        part:repair()
+
+        player:sendObjectChange('mechanicActionDone', {
+            success = true,
+            vehicleId = vehicle:getId(),
+            partId = part:getId(),
+            itemId = -1,
+            installing = true
+        })
+    else
+        noise('no such vehicle id='..tostring(args.vehicle))
+    end
+end
+
+local function OnClientCommand(module, command, player, args)
+    if module == 'vehicle' and command == 'repairHeater' then
+        Commands.repairHeater(player, args)
+    end
+end
+
+Events.OnClientCommand.Add(OnClientCommand)

--- a/Contents/mods/PatagoniaTools/media/lua/shared/Translate/AR/IG_UI_AR.txt
+++ b/Contents/mods/PatagoniaTools/media/lua/shared/Translate/AR/IG_UI_AR.txt
@@ -4,4 +4,5 @@ IGUI_AR = {
     IGUI_Electricity = "Electrónica: %.2f",
     IGUI_RepairEngineQuality = "Reparar calidad del motor",
     IGUI_RestoreTrunk = "Restaurar maletero",
+    IGUI_Restore_Heater = "Restaurar el climatizador"
 }

--- a/Contents/mods/PatagoniaTools/media/lua/shared/Translate/AR/Tooltip_AR.txt
+++ b/Contents/mods/PatagoniaTools/media/lua/shared/Translate/AR/Tooltip_AR.txt
@@ -5,4 +5,5 @@ Tooltip_AR = {
     Tooltip_vehicle_RestoreTrunkWarning = "Restaura al 100% el maletero, sin considerar las reparaciones anteriores.",
     Tooltip_part_full = "No requiere reparación.",
     Tooltip_blow_torch_fully_charged = "%1 completamente cargado.",
+    Tooltip_vehicle_RestoreHeaterWarning = "Restaura el climatizador al 100%.",
 }

--- a/Contents/mods/PatagoniaTools/media/lua/shared/Translate/EN/IG_UI_EN.txt
+++ b/Contents/mods/PatagoniaTools/media/lua/shared/Translate/EN/IG_UI_EN.txt
@@ -4,4 +4,5 @@ IGUI_EN = {
     IGUI_Electricity = "Electricity: %.2f",
     IGUI_RepairEngineQuality = "Repair Engine Quality",
     IGUI_RestoreTrunk = "Restore trunk",
+    IGUI_Restore_Heater = "Restore heater"
 }

--- a/Contents/mods/PatagoniaTools/media/lua/shared/Translate/EN/Tooltip_EN.txt
+++ b/Contents/mods/PatagoniaTools/media/lua/shared/Translate/EN/Tooltip_EN.txt
@@ -5,4 +5,5 @@ Tooltip_EN = {
     Tooltip_vehicle_RestoreTrunkWarning = "Restores the trunk to 100%, regardless of previous repairs.",
     Tooltip_part_full = "No repair required.",
     Tooltip_blow_torch_fully_charged = "%1 Fully Charged.",
+    Tooltip_vehicle_RestoreHeaterWarning = "Restores the heater to 100%.",
 }

--- a/Contents/mods/PatagoniaTools/media/lua/shared/Translate/ES/IG_UI_ES.txt
+++ b/Contents/mods/PatagoniaTools/media/lua/shared/Translate/ES/IG_UI_ES.txt
@@ -4,4 +4,5 @@ IGUI_ES = {
     IGUI_Electricity = "Electrónica: %.2f",
     IGUI_RepairEngineQuality = "Reparar calidad del motor",
     IGUI_RestoreTrunk = "Restaurar maletero",
+    IGUI_Restore_Heater = "Restaurar el climatizador"
 }

--- a/Contents/mods/PatagoniaTools/media/lua/shared/Translate/ES/Tooltip_ES.txt
+++ b/Contents/mods/PatagoniaTools/media/lua/shared/Translate/ES/Tooltip_ES.txt
@@ -5,4 +5,5 @@ Tooltip_ES = {
     Tooltip_vehicle_RestoreTrunkWarning = "Restaura al 100% el maletero, sin considerar las reparaciones anteriores.",
     Tooltip_part_full = "No requiere reparación",
     Tooltip_blow_torch_fully_charged = "%1 completamente cargado.",
+    Tooltip_vehicle_RestoreHeaterWarning = "Restaura el climatizador al 100%.",
 }


### PR DESCRIPTION
An option is enabled, when clicking on the air conditioner, so that it can be repaired, choosing the electronics profession as a base, and some materials, which later on, we will try to make them customizable, so that not only the quantities can be modified, but also the materials, professions (so it can be adapted to as many games as possible).